### PR TITLE
Add support for XML output to use with minipro

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Flags:
 
       --toml              Output as toml
       --json              Output as json
+      --xml               Output as xml
 ```
 
 `describe <path>` which reads an `.lgc` file and dumps some information about the contents to stdout:
@@ -62,7 +63,7 @@ Entry #0
                 #1: 0 1 0 G 0 0 0 V 
 ```
 
-You can supply the optional flags `--toml` or `--json` to pipe the data into another tool (such as `jq`).
+You can supply the optional flags `--toml`, `--json` or `--xml` to pipe the data into another tool (such as `jq`).
 
 ### LGC
 `lgc <input> <output>` reads an input file and outputs an `.lgc` file that can be imported into the Xgpro tool.
@@ -152,6 +153,36 @@ The json format is structurally identical to the `toml` format.
 }
 ```
 
+### Example XML file
+
+The xml format is made to be compatible with the linux/mac version of minipro.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<infoic>
+  <database device="TL866II">
+    <manufacturer name="Logic Ic">
+      <ic name="OLI's IC" pins="8" voltage="5.0V" type="5">
+        <vector id="00"> 1 0 0 G 0 0 0 V </vector>
+        <vector id="01"> 0 1 0 G 0 0 0 V </vector>
+      </ic>
+      <ic name="Another IC" pins="10" voltage="3.3V" type="5">
+        <vector id="00"> 1 0 0 0 G 0 0 0 0 V </vector>
+        <vector id="01"> 0 1 0 0 G 0 0 0 0 V </vector>
+      </ic>
+    </manufacturer>
+  </database>
+</infoic>
+```
+
+WARNING: The voltage and type in minipro are always 5V and 5 respectively for all ICs, so
+it might be that these are not used. In this xml export implementation, voltage will output vcc
+and type is hardcoded to 5.
+```
+$xgpro-logic describe examples/test_1j.lgc --xml > examples/test_1j.xml
+
+$minipro -logicic examples/test_1j.xml -p "OLI's IC" -T
+```
 
 ## Building
 

--- a/cmd/xgpro-logic.app/main.go
+++ b/cmd/xgpro-logic.app/main.go
@@ -15,6 +15,7 @@ type ViewCmd struct {
 	Path       string `arg required help:"Input path." type:"path"`
 	Toml       bool   `xor:"format" help:"Output as toml" type:"bool"`
 	Json       bool   `xor:"format" help:"Output as json" type:"bool"`
+	Xml        bool   `xor:"format" help:"Output as xml" type:"bool"`
 	OutputFile string `short:"o" help:"Output file path." type:"path"`
 }
 
@@ -44,6 +45,9 @@ func (cmd *ViewCmd) Run(globals *Globals) error {
 	}
 	if cmd.Json {
 		return xgpro.DescribeJson(lgc, file)
+	}
+	if cmd.Xml {
+		return xgpro.DescribeXml(lgc, file)
 	}
 
 	return xgpro.DumpLGCFile(lgc, file)


### PR DESCRIPTION
I got here from breakintoprogram, thanks both! I wanted to test my PLA using his files and your tool, but I'm not on windows, I use minipro (command line unix flavour) on OS X. This tool won't understand toml, instead it has an XML database of ICs for this. 
I read your code and saw that it would be immediate to produce another output in xml same as you have done with json.
To keep it consistent with your programming and your JSON output, I have not used any XML library and just print strings of text that happen to be XML.
There's a couple of "oh well" things with the voltage and type attributes. I don't really know what they are for, and they don't seem to change in any of the hundreds of ICs in minipro's db. I can contact the author maybe.
I have done very very little testing, I tested BreakIntoProgram's PLA and worked as a charm, and just run your two test files in /examples to eyeball if the output made sense.